### PR TITLE
Update command to work on pr events

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,6 +11,12 @@ if [[ "$current_branch" != 'master' && $max_depth -eq 0 ]]; then
   exit 0
 fi
 
+if [[ "$current_branch" == "HEAD" ]]; then
+  current_branch="check-secrets-from-pr"
+  echo "checking out to $current_branch"
+  git checkout -b $current_branch
+fi
+
 args="--regex --rules /regexes.json --branch ${current_branch} --json -x /.ignorelist" # Default trufflehog options
 if [[ $max_depth -gt 0 ]]; then
   args="$args --max_depth=${max_depth}"


### PR DESCRIPTION
Atualiza função de buscar o nome da branch

PS: fiz checkout para evitar que quebre por causa do detach que é feito quando é feito o checkout via actions, tentei usar a referencia da branch, passada por quem chama a action, mas não deu certo pois a referencia da branch não estava presente no repositorio local.