### PR TITLE
Ignore iOS project file

### DIFF
--- a/.ignorelist
+++ b/.ignorelist
@@ -4,3 +4,4 @@
 (.*/)?Podfile.lock
 (.*/)?pubspec.lock
 (.*/)?project.pbxproj
+(.*/)?(.*).xcscheme

--- a/.ignorelist
+++ b/.ignorelist
@@ -3,3 +3,4 @@
 (.*/)?package-lock.json
 (.*/)?Podfile.lock
 (.*/)?pubspec.lock
+(.*/)?project.pbxproj


### PR DESCRIPTION
We're having an issue with [this file](https://github.com/contratadome/candidates-flutter-app/blob/28633cc9b1ff9569dc702ad32c70414e14df18fd/ios/Runner.xcodeproj/project.pbxproj). It's a project configuration file and has many hash values.

We probably could apply ignore patterns instead of ignoring the whole file, but for now we need this.